### PR TITLE
FakeCAS adjusted to better simulate real authentication flow

### DIFF
--- a/lib/rack/fake_cas.rb
+++ b/lib/rack/fake_cas.rb
@@ -5,6 +5,14 @@ class Rack::FakeCAS
 
   @@cas_session = nil
 
+  def self.mock_cas_session!(email: 'email@example.com')
+    @@cas_session = { email: email }
+  end
+
+  def self.unmock_cas_session!
+    @@cas_session = nil
+  end
+
   def initialize(app, config={}, attributes_config={})
     @app = app
     @config = config || {}

--- a/lib/rack/fake_cas.rb
+++ b/lib/rack/fake_cas.rb
@@ -2,6 +2,9 @@ require 'rack'
 require 'rack-cas/cas_request'
 
 class Rack::FakeCAS
+
+  @@cas_session_present = false
+
   def initialize(app, config={}, attributes_config={})
     @app = app
     @config = config || {}
@@ -18,32 +21,47 @@ class Rack::FakeCAS
 
     case @request.path_info
     when '/login'
-      username = @request.params['username']
-      @request.session['cas'] = {}
-      @request.session['cas']['user'] = username
-      @request.session['cas']['extra_attributes'] = @attributes_config.fetch(username, {})
+      # simulates CAS service (when no CAS session: login page, when CAS session present: redirect back to app)
+      # can be also used as a built-in way to get to the login page without needing to return a 401 status
+      if @@cas_session_present
+        redirect_to @request.params['service'] + '?ticket=some-value'
+      else
+        render_login_page
+      end
+
+    when '/logged_in'
+      # simulates real CAS redirect back to app after establishing CAS session
+      @@cas_session_present = true # counterpart of setting a session cookie in real CAS
       redirect_to @request.params['service']
 
     when '/logout'
+      @@cas_session_present = false
       @request.session.send respond_to?(:destroy) ? :destroy : :clear
       redirect_to "#{@request.script_name}/"
 
-    # built-in way to get to the login page without needing to return a 401 status
-    when '/fake_cas_login'
-      render_login_page
-
     else
-      response = @app.call(env)
-
-      if response[0] == 401 # access denied
-        render_login_page
+      if @request.params['ticket'] # simulates ticket validation
+        save_cas_data_to_session
+        redirect_to @request.base_url + @request.path
       else
-        response
+        response = @app.call(env)
+        if response[0] == 401 # access denied - app did not found CAS session data
+          redirect_to "#{@request.base_url}/login?service=#{@request.url}"
+        else
+          response
+        end
       end
     end
   end
 
   protected
+
+  def save_cas_data_to_session
+    username = @request.params['username']
+    @request.session['cas'] = {}
+    @request.session['cas']['user'] = 'fake-username'
+    @request.session['cas']['extra_attributes'] = @attributes_config.fetch(username, {})
+  end
 
   def render_login_page
     [ 200, { 'Content-Type' => 'text/html' }, [login_page] ]
@@ -58,8 +76,8 @@ class Rack::FakeCAS
     <title>Fake CAS</title>
   </head>
   <body>
-    <form action="#{@request.script_name}/login" method="post">
-      <input type="hidden" name="service" value="#{@request.url}"/>
+    <form action="#{@request.script_name}/logged_in" method="post">
+      <input type="hidden" name="service" value="#{@request.params['service']}"/>
       <label for="username">Username</label>
       <input id="username" name="username" type="text"/>
       <label for="password">Password</label>

--- a/spec/rack/fake_cas_spec.rb
+++ b/spec/rack/fake_cas_spec.rb
@@ -13,21 +13,56 @@ describe Rack::FakeCAS do
   end
 
   describe 'auth required request' do
+    before do
+      described_class.class_variable_set('@@cas_session_present', false)
+    end
+
     subject { get '/private' }
-    its(:status) { should eql 200 }
-    its(:body) { should match /username/ }
-    its(:body) { should match /password/ }
+    it { should be_redirect }
+    its(:location) { should eql 'http://example.org/login?service=http://example.org/private' }
+    its(:headers) { }
   end
 
-  describe 'login page request' do
-    subject { get '/fake_cas_login' }
-    its(:status) { should eql 200 }
-    its(:body) { should match /username/ }
-    its(:body) { should match /password/ }
+  describe 'fake_cas_login request' do
+    before do
+      described_class.class_variable_set('@@cas_session_present', cas_session_present)
+      get '/login', username: 'janed0', service: 'http://example.org/private'
+    end
+
+    context 'without cas session' do
+      let(:cas_session_present){ false }
+
+      subject { last_response }
+      its(:status) { should eql 200 }
+      its(:body) { should match /username/ }
+      its(:body) { should match /password/ }
+
+      describe 'session' do
+        subject { last_request.session['cas'] }
+        it { should be_nil }
+      end
+    end
+
+    context 'with cas session' do
+      let(:cas_session_present){ true }
+
+      subject { last_response }
+      it { should be_redirect }
+      its(:location) { should eql 'http://example.org/private?ticket=some-value' }
+
+      describe 'session' do
+        subject { last_request.session['cas'] }
+        it { should be_nil }
+      end
+    end
+
   end
 
   describe 'login request' do
-    before { get '/login', username: 'janed0', service: 'http://example.org/private' }
+    before do
+      described_class.class_variable_set('@@cas_session_present', false)
+      get '/logged_in', username: 'janed0', service: 'http://example.org/private'
+    end
 
     subject { last_response }
     it { should be_redirect }
@@ -35,9 +70,26 @@ describe Rack::FakeCAS do
 
     describe 'session' do
       subject { last_request.session['cas'] }
+      it { should be_nil }
+    end
+
+    it 'should have cas_session_present class variable set to true' do
+      expect(described_class.class_variable_get('@@cas_session_present')).to be(true)
+      subject
+    end
+  end
+
+  describe 'ticket validation request' do
+    before { get '/private', ticket: 'some-value' }
+
+    subject { last_response }
+    it { should be_redirect }
+    its(:location) { should eql 'http://example.org/private' }
+    its(:headers) { }
+
+    describe 'session' do
+      subject { last_request.session['cas'] }
       it { should_not be_nil }
-      its(['user']) { should eql 'janed0' }
-      its(['extra_attributes']) { should eql({}) }
     end
   end
 
@@ -73,7 +125,10 @@ describe Rack::FakeCAS do
                         })
     end
 
-    before { get '/login', username: 'janed0', service: 'http://example.org/private' }
+    before do
+      described_class.class_variable_set('@@cas_session_present', true)
+      get '/private', username: 'janed0', ticket: 'some-value'
+    end
 
     describe 'session' do
       subject { last_request.session['cas'] }

--- a/spec/rack/fake_cas_spec.rb
+++ b/spec/rack/fake_cas_spec.rb
@@ -141,4 +141,41 @@ describe Rack::FakeCAS do
                                               'email2' => 'janed0@example.com'}) }
     end
   end
+
+  describe 'cas session mocking' do
+
+    context 'default email' do
+      subject{ described_class.mock_cas_session! }
+
+      it 'sets cas_session clas variable' do
+        subject
+        expect(described_class.class_variable_get('@@cas_session')).to eq(email: 'email@example.com')
+      end
+    end
+
+    context 'with provided email' do
+      subject{ described_class.mock_cas_session!(email: 'provided@email.com') }
+
+      it 'sets cas_session clas variable' do
+        subject
+        expect(described_class.class_variable_get('@@cas_session')).to eq(email: 'provided@email.com')
+      end
+    end
+
+  end
+
+  describe 'cas session unmocking' do
+
+    subject{ described_class.unmock_cas_session! }
+
+    before do
+      described_class.class_variable_set('@@cas_session', { email: 'some.email@example.com' })
+    end
+
+    it 'sets cas_session clas variable' do
+      subject
+      expect(described_class.class_variable_get('@@cas_session')).to be_nil
+    end
+
+  end
 end


### PR DESCRIPTION
FakeCAS authentication flow was logically very different (much simpler) than the real one.

This change aligns FakeCAS flow with the real one in terms of:
- app<->cas redirects flow
- moment when rack session is created
- persistent state of CAS session (implemented as class variable)
- CAS url paths
 
I also changed `username` to `email` in code & login template, since as far as I know we always treat this username as email.

I made this PR because:
- I already had most of those changes done locally while testing new authentication flow for separate FE 
- integration between `rack-cas` and a separate FE will be much tighter than with "monolithic" apps - without this change we'd have to pollute new FE code with adjustments to a different flow in development
- at first I got misled by the old FakeCAS implementation (I assumed that it more-less corresponds to the real one), let no-one else repeat my mistake :)
