### PR TITLE
Redis session store: support for redis gem >= 5.0.0

### DIFF
--- a/lib/rack-cas/session_store/redis.rb
+++ b/lib/rack-cas/session_store/redis.rb
@@ -16,11 +16,11 @@ module RackCAS
       def self.write(session_id:, data:, cas_ticket:, expire_after: nil)
         #create a row with the session_id and the data
         #create a row with the cas_ticket acting as a reverse index
-        results = self.client.pipelined do
-          self.client.set("rack_cas_session:#{session_id}",data)
-          self.client.expireat("rack_cas_session:#{session_id}",expire_after.present? ? expire_after.from_now.to_i : 30.days.from_now.to_i)
-          self.client.set("rack_cas_ticket:#{cas_ticket}","rack_cas_session:#{session_id}")
-          self.client.expireat("rack_cas_ticket:#{cas_ticket}",expire_after.present? ? expire_after.from_now.to_i : 30.days.from_now.to_i)
+        results = self.pipelined__redis_version_safe do |client_or_pipeline|
+          client_or_pipeline.set("rack_cas_session:#{session_id}",data)
+          client_or_pipeline.expireat("rack_cas_session:#{session_id}",expire_after.present? ? expire_after.from_now.to_i : 30.days.from_now.to_i)
+          client_or_pipeline.set("rack_cas_ticket:#{cas_ticket}","rack_cas_session:#{session_id}")
+          client_or_pipeline.expireat("rack_cas_ticket:#{cas_ticket}",expire_after.present? ? expire_after.from_now.to_i : 30.days.from_now.to_i)
         end
 
         results == ["OK",true,"OK",true] ? session_id : false
@@ -28,15 +28,27 @@ module RackCAS
 
       def self.destroy_by_cas_ticket(cas_ticket)
         session_id = self.client.get("rack_cas_ticket:#{cas_ticket}")
-        results = self.client.pipelined do
-          self.client.del("rack_cas_ticket:#{cas_ticket}")
-          self.client.del(session_id)
+        results = self.pipelined__redis_version_safe do |client_or_pipeline|
+          client_or_pipeline.del("rack_cas_ticket:#{cas_ticket}")
+          client_or_pipeline.del(session_id)
         end
         return results[1]
       end
 
       def self.delete(session_id)
         self.client.del("rack_cas_session:#{session_id}")
+      end
+
+      def self.pipelined__redis_version_safe(&write_operations)
+        # version 5.0.0 of redis gem changed signature of "pipelined" method:
+        #   > Commands now MUST be called on the block argument, not the original redis instance.
+        # (from https://github.com/redis/redis-rb/blob/master/CHANGELOG.md)
+
+        if Gem::Version.new(Redis::VERSION) < Gem::Version.new('5.0.0')
+          self.client.pipelined{ write_operations.call(self.client) }
+        else
+          self.client.pipelined(&write_operations)
+        end
       end
     end
 


### PR DESCRIPTION
Redis gem in ver 5.0.0 changed the signature of `pipelined` method:
  > Commands now MUST be called on the block argument, not the original redis instance.

(from https://github.com/redis/redis-rb/blob/master/CHANGELOG.md)

Current implementation of `RackCAS::RedisStore::Session` works only with the older signature -> **prevents from upgrading to the newer versions of redis gem**.

This PR introduces conditional support for both signatures.