### PR TITLE
FakeCAS: service query params support

### DIFF
--- a/lib/rack/fake_cas.rb
+++ b/lib/rack/fake_cas.rb
@@ -95,7 +95,8 @@ class Rack::FakeCAS
     service_uri = URI(url_string)
     query_params = Rack::Utils.parse_query service_uri.query
     block.yield(query_params)
-    service_uri.query = Rack::Utils.build_query(query_params)
+    query = query_params.empty? ? nil : Rack::Utils.build_query(query_params)
+    service_uri.query = query
     service_uri.to_s
   end
 


### PR DESCRIPTION
- FakeCAS assumed that `service` url does not have query params -> `ticket` param was just appended at the end of the url
- we added query param in payments -> it did not work :D (`https://some.url.com?path=/?ticket=some-value`)
- now it works :)