### PR TITLE
Fix csrf issue on rails 7.1

### DIFF
--- a/lib/rack-cas/session_store/active_record.rb
+++ b/lib/rack-cas/session_store/active_record.rb
@@ -1,7 +1,8 @@
 require 'rack/session/abstract/id'
+require 'action_dispatch/middleware/session/abstract_store'
 
 module RackCAS
-  class ActiveRecordStore < Rack::Session::Abstract::PersistedSecure
+  class ActiveRecordStore < ActionDispatch::Session::AbstractSecureStore
 
     class Session < ActiveRecord::Base
     end


### PR DESCRIPTION
From rails 7 there is new behavior about commit csrf token into session.
the csrf token only commit when SessionObject included from actionpack/lib/action_dispatch/middleware/session/abstract_store.rb. that why we have to inherit ActionDispatch::Session::AbstractSecureStore from ActiveRecordStore so that SessionObject loaded and execute commit_session method
https://github.com/rails/rails/pull/44283/files